### PR TITLE
Fix the `VisitInitListExpr` pop type

### DIFF
--- a/lib/Frontend/nvqpp/ConvertDecl.cpp
+++ b/lib/Frontend/nvqpp/ConvertDecl.cpp
@@ -631,6 +631,12 @@ bool QuakeBridgeVisitor::VisitVarDecl(clang::VarDecl *x) {
     return pushValue(callable);
   }
 
+  if (auto arrayType = dyn_cast<cc::ArrayType>(type)) {
+    auto array = popValue();
+    symbolTable.insert(name, array);
+    return pushValue(array);
+  }
+
   // Variable is of some basic type not already handled. Create a local stack
   // slot in which to save the value. This stack slot is the variable in the
   // memory domain.

--- a/lib/Frontend/nvqpp/ConvertDecl.cpp
+++ b/lib/Frontend/nvqpp/ConvertDecl.cpp
@@ -631,12 +631,6 @@ bool QuakeBridgeVisitor::VisitVarDecl(clang::VarDecl *x) {
     return pushValue(callable);
   }
 
-  if (auto arrayType = dyn_cast<cc::ArrayType>(type)) {
-    auto array = popValue();
-    symbolTable.insert(name, array);
-    return pushValue(array);
-  }
-
   // Variable is of some basic type not already handled. Create a local stack
   // slot in which to save the value. This stack slot is the variable in the
   // memory domain.

--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -951,7 +951,7 @@ bool QuakeBridgeVisitor::VisitMaterializeTemporaryExpr(
   // temporary memory location and push the address to the stack.
 
   // Is it already materialized in memory?
-  if (isa<cc::PointerType, cc::ArrayType>(ty))
+  if (isa<cc::PointerType>(ty))
     return true;
 
   // Materialize the value into a glvalue location in memory.
@@ -1659,21 +1659,12 @@ bool QuakeBridgeVisitor::VisitCXXOperatorCallExpr(
       // are accessing it like theta[i].
       auto indexVar = popValue();
       auto svec = popValue();
-      Value eleAddr;
-      if (isa<cc::StdvecType>(svec.getType())) {
-        assert(svec.getType().isa<cc::StdvecType>());
-        auto eleTy = cast<cc::StdvecType>(svec.getType()).getElementType();
-        auto elePtrTy = cc::PointerType::get(eleTy);
-        auto vecPtr = builder.create<cc::StdvecDataOp>(loc, elePtrTy, svec);
-        eleAddr = builder.create<cc::ComputePtrOp>(loc, elePtrTy, vecPtr,
-                                                   ValueRange{indexVar});
-      } else if (auto arrTy = dyn_cast<cc::ArrayType>(svec.getType()))
-        eleAddr = builder.create<cc::GetConstantElementOp>(
-            loc, arrTy.getElementType(), svec, indexVar);
-
-      if (!eleAddr)
-        TODO_loc(loc, "unhandled array-like operator[] indexing.");
-
+      assert(svec.getType().isa<cc::StdvecType>());
+      auto eleTy = cast<cc::StdvecType>(svec.getType()).getElementType();
+      auto elePtrTy = cc::PointerType::get(eleTy);
+      auto vecPtr = builder.create<cc::StdvecDataOp>(loc, elePtrTy, svec);
+      auto eleAddr = builder.create<cc::ComputePtrOp>(loc, elePtrTy, vecPtr,
+                                                      ValueRange{indexVar});
       return replaceTOSValue(eleAddr);
     }
     if (typeName == "_Bit_reference") {

--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -1838,43 +1838,31 @@ bool QuakeBridgeVisitor::VisitInitListExpr(clang::InitListExpr *x) {
     return pushValue(last[0]);
   }
 
-  // Check if all values here are Integer or Float Type
-  bool isAllIntOrAllFloat = [&]() {
-    for (auto v : last)
-      if (!v.getType().isIntOrFloat())
-        return false;
-    return true;
-  }();
+  // Let's allocate some memory and store the init list elements there.
 
-  // If these are integers or floats, then let's allocate
-  // some memory and store them there.
-  if (isAllIntOrAllFloat) {
-    // Clear the types for the init expr
-    typeStack.clear();
+  // Clear the types for the init expr
+  for (std::size_t i = 0; i < size; i++)
+    popType();
 
-    // This is a initlist on ints or floats, get which one
-    Type dataType = last.front().getType();
+  // This is a initlist on ints or floats, get which one
+  Type dataType = last.front().getType();
 
-    // Add the array size value
-    Value arrSize =
-        getConstantInt(builder, loc, last.size(), builder.getI64Type());
+  // Add the array size value
+  Value arrSize =
+      getConstantInt(builder, loc, last.size(), builder.getI64Type());
 
-    // Allocate the required memory chunk
-    Value alloca = builder.create<cc::AllocaOp>(loc, dataType, arrSize);
+  // Allocate the required memory chunk
+  Value alloca = builder.create<cc::AllocaOp>(loc, dataType, arrSize);
 
-    // Store the values in the allocated memory
-    for (std::size_t i = 0; auto v : last) {
-      Value ptr = builder.create<cc::ComputePtrOp>(
-          loc, cc::PointerType::get(dataType), alloca,
-          getConstantInt(builder, loc, i++, builder.getI64Type()));
-      builder.create<cc::StoreOp>(loc, v, ptr);
-    }
-
-    return pushValue(alloca);
+  // Store the values in the allocated memory
+  for (std::size_t i = 0; auto v : last) {
+    Value ptr = builder.create<cc::ComputePtrOp>(
+        loc, cc::PointerType::get(dataType), alloca,
+        getConstantInt(builder, loc, i++, builder.getI64Type()));
+    builder.create<cc::StoreOp>(loc, v, ptr);
   }
 
-  TODO_x(loc, x, mangler, "list initialization (not quantum ref)");
-  return true;
+  return pushValue(alloca);
 }
 
 bool QuakeBridgeVisitor::TraverseCXXConstructExpr(clang::CXXConstructExpr *x,
@@ -1985,34 +1973,65 @@ bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
         return true;
       }
 
-      if (ctorName == "vector") {
+      if (ctorName == "vector" && x->getNumArgs() == 2) {
+        // Here we create a lambda that will peel off the sugar types
+        auto peelOffClangTypes = [&](clang::QualType type) {
+          clang::QualType lastType = type;
+          while (true) {
+            type = type.getSingleStepDesugaredType(*astContext);
+            if (type == lastType)
+              break;
+            lastType = type;
+          }
+
+          return lastType;
+        };
+
         // This is a std::vector constructor, first we'll check if it
         // is constructed from a constant initializer list, in that case
         // we'll have a AllocaOp at the top of the stack that allocates a
         // ptr<array<TxC>>, where C is constant / known
-        if (auto alloca = dyn_cast<cc::AllocaOp>(peekValue().getDefiningOp())) {
-          auto asPtrType =
-              dyn_cast<cc::PointerType>(alloca.getAddress().getType());
-          if (auto arrayTy =
-                  dyn_cast<cc::ArrayType>(asPtrType.getElementType()))
-            if (alloca.getNumOperands() > 0)
-              return pushValue(builder.create<cc::StdvecInitOp>(
-                  loc, cc::StdvecType::get(arrayTy.getElementType()), alloca,
-                  alloca.getSeqSize()));
+        auto type = x->getArg(0)->getType();
+        auto desugared = peelOffClangTypes(type);
+        if (auto recordType =
+                dyn_cast<clang::RecordType>(desugared.getTypePtr())) {
+          if (recordType->getDecl()->getName().equals("initializer_list")) {
+            auto allocation = popValue();
+            if (auto ptrTy = dyn_cast<cc::PointerType>(allocation.getType())) {
+              if (auto arrayTy =
+                      dyn_cast<cc::ArrayType>(ptrTy.getElementType())) {
+                if (auto definingOp = allocation.getDefiningOp<cc::AllocaOp>())
+                  return pushValue(builder.create<cc::StdvecInitOp>(
+                      loc, cc::StdvecType::get(arrayTy.getElementType()),
+                      allocation, definingOp.getSeqSize()));
+              }
+            }
+          }
         }
 
-        // Next check if its created from a size integer
-        if (peekValue().getType().isIntOrFloat()) {
-          auto arrSize = popValue();
-          auto dataType = popType();
+        // Next check if its created from a size integer, we should have an
+        // integer value on the stack, and the constructor should have 2 args
+        // one for the size and another for the allocator
 
-          // create stdvec init op without a buffer.
-          // Allocate the required memory chunk
-          Value alloca = builder.create<cc::AllocaOp>(loc, dataType, arrSize);
+        // Lets do a check on the first argument, make sure that when
+        // we peel off all the typedefs that it is an integer
+        if (auto builtInType =
+                dyn_cast<clang::BuiltinType>(desugared.getTypePtr())) {
+          if (builtInType->isInteger() &&
+              peekValue().getType().isIntOrFloat()) {
+            // This is an integer argument, and the value on the stack
+            // is an integer, so let's connect them up
+            auto arrSize = popValue();
+            auto dataType = popType();
 
-          // Create the stdvec_init op
-          return pushValue(builder.create<cc::StdvecInitOp>(
-              loc, cc::StdvecType::get(dataType), alloca, arrSize));
+            // create stdvec init op without a buffer.
+            // Allocate the required memory chunk
+            Value alloca = builder.create<cc::AllocaOp>(loc, dataType, arrSize);
+
+            // Create the stdvec_init op
+            return pushValue(builder.create<cc::StdvecInitOp>(
+                loc, cc::StdvecType::get(dataType), alloca, arrSize));
+          }
         }
 
         // Disallow any default vector construction bc we don't
@@ -2036,8 +2055,7 @@ bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
     // 1) A unique object must be created, so the type must have a minimum of
     //    one byte.
     // 2) Allocate a new object.
-    // 3) Call the constructor passing the address of the allocation as
-    // `this`.
+    // 3) Call the constructor passing the address of the allocation as `this`.
 
     // FIXME: As this is now, the stack space isn't correctly sized. The
     // next line should be something like:

--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -951,7 +951,7 @@ bool QuakeBridgeVisitor::VisitMaterializeTemporaryExpr(
   // temporary memory location and push the address to the stack.
 
   // Is it already materialized in memory?
-  if (isa<cc::PointerType>(ty))
+  if (isa<cc::PointerType, cc::ArrayType>(ty))
     return true;
 
   // Materialize the value into a glvalue location in memory.
@@ -1659,12 +1659,21 @@ bool QuakeBridgeVisitor::VisitCXXOperatorCallExpr(
       // are accessing it like theta[i].
       auto indexVar = popValue();
       auto svec = popValue();
-      assert(svec.getType().isa<cc::StdvecType>());
-      auto eleTy = cast<cc::StdvecType>(svec.getType()).getElementType();
-      auto elePtrTy = cc::PointerType::get(eleTy);
-      auto vecPtr = builder.create<cc::StdvecDataOp>(loc, elePtrTy, svec);
-      auto eleAddr = builder.create<cc::ComputePtrOp>(loc, elePtrTy, vecPtr,
-                                                      ValueRange{indexVar});
+      Value eleAddr;
+      if (isa<cc::StdvecType>(svec.getType())) {
+        assert(svec.getType().isa<cc::StdvecType>());
+        auto eleTy = cast<cc::StdvecType>(svec.getType()).getElementType();
+        auto elePtrTy = cc::PointerType::get(eleTy);
+        auto vecPtr = builder.create<cc::StdvecDataOp>(loc, elePtrTy, svec);
+        eleAddr = builder.create<cc::ComputePtrOp>(loc, elePtrTy, vecPtr,
+                                                   ValueRange{indexVar});
+      } else if (auto arrTy = dyn_cast<cc::ArrayType>(svec.getType()))
+        eleAddr = builder.create<cc::GetConstantElementOp>(
+            loc, arrTy.getElementType(), svec, indexVar);
+
+      if (!eleAddr)
+        TODO_loc(loc, "unhandled array-like operator[] indexing.");
+
       return replaceTOSValue(eleAddr);
     }
     if (typeName == "_Bit_reference") {
@@ -1837,6 +1846,34 @@ bool QuakeBridgeVisitor::VisitInitListExpr(clang::InitListExpr *x) {
     // Pass initialization list with one member as a Ref.
     return pushValue(last[0]);
   }
+
+  // Handle initializer lists like {1.1, 2.2, 3.3,...}
+  // or the same for integers
+  bool isAllIntOrAllFloat = [&]() {
+    for (auto v : last)
+      if (!v.getType().isIntOrFloat())
+        return false;
+    return true;
+  }();
+  if (isAllIntOrAllFloat) {
+    SmallVector<Attribute> constantValues;
+    for (auto v : last) {
+      Type type = v.getType();
+      if (auto constantOp = v.getDefiningOp<arith::ConstantFloatOp>())
+        constantValues.push_back(
+            builder.getFloatAttr(type, constantOp.value()));
+      if (auto constantOp = v.getDefiningOp<arith::ConstantIntOp>())
+        constantValues.push_back(
+            builder.getIntegerAttr(type, constantOp.value()));
+    }
+    // Clear the types for the init expr
+    typeStack.clear();
+    return pushValue(builder.create<cc::ConstantArrayOp>(
+        loc,
+        cc::ArrayType::get(builder.getContext(), last.front().getType(), size),
+        builder.getArrayAttr(constantValues)));
+  }
+
   TODO_x(loc, x, mangler, "list initialization (not quantum ref)");
   return true;
 }
@@ -1947,6 +1984,14 @@ bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
         [[maybe_unused]] auto tosTy = peekValue().getType();
         assert((isa<quake::RefType, quake::VeqType>(tosTy)));
         return true;
+      }
+
+      if (ctorName == "vector") {
+        // This is a std::vector constructor, first we'll check if it
+        // is constructed from a constant initializer list
+        if (auto arrTy = dyn_cast<cc::ArrayType>(peekValue().getType()))
+          if (arrTy.getSize() != cc::ArrayType::unknownSize)
+            return true;
       }
     }
 

--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -1838,14 +1838,16 @@ bool QuakeBridgeVisitor::VisitInitListExpr(clang::InitListExpr *x) {
     return pushValue(last[0]);
   }
 
-  // Handle initializer lists like {1.1, 2.2, 3.3,...}
-  // or the same for integers
+  // Check if all values here are Integer or Float Type
   bool isAllIntOrAllFloat = [&]() {
     for (auto v : last)
       if (!v.getType().isIntOrFloat())
         return false;
     return true;
   }();
+
+  // If these are integers or floats, then let's allocate
+  // some memory and store them there.
   if (isAllIntOrAllFloat) {
     // Clear the types for the init expr
     typeStack.clear();
@@ -1868,9 +1870,7 @@ bool QuakeBridgeVisitor::VisitInitListExpr(clang::InitListExpr *x) {
       builder.create<cc::StoreOp>(loc, v, ptr);
     }
 
-    // Create the stdvec_init op
-    return pushValue(builder.create<cc::StdvecInitOp>(
-        loc, cc::StdvecType::get(dataType), alloca, arrSize));
+    return pushValue(alloca);
   }
 
   TODO_x(loc, x, mangler, "list initialization (not quantum ref)");
@@ -1987,10 +1987,19 @@ bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
 
       if (ctorName == "vector") {
         // This is a std::vector constructor, first we'll check if it
-        // is constructed from a constant initializer list, if
-        // so the top value will have stdvec type, and we can just drop out
-        if (isa<cc::StdvecType>(peekValue().getType()))
-          return true;
+        // is constructed from a constant initializer list, in that case
+        // we'll have a AllocaOp at the top of the stack that allocates a
+        // ptr<array<TxC>>, where C is constant / known
+        if (auto alloca = dyn_cast<cc::AllocaOp>(peekValue().getDefiningOp())) {
+          auto asPtrType =
+              dyn_cast<cc::PointerType>(alloca.getAddress().getType());
+          if (auto arrayTy =
+                  dyn_cast<cc::ArrayType>(asPtrType.getElementType()))
+            if (alloca.getNumOperands() > 0)
+              return pushValue(builder.create<cc::StdvecInitOp>(
+                  loc, cc::StdvecType::get(arrayTy.getElementType()), alloca,
+                  alloca.getSeqSize()));
+        }
 
         // Next check if its created from a size integer
         if (peekValue().getType().isIntOrFloat()) {
@@ -2027,7 +2036,8 @@ bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
     // 1) A unique object must be created, so the type must have a minimum of
     //    one byte.
     // 2) Allocate a new object.
-    // 3) Call the constructor passing the address of the allocation as `this`.
+    // 3) Call the constructor passing the address of the allocation as
+    // `this`.
 
     // FIXME: As this is now, the stack space isn't correctly sized. The
     // next line should be something like:

--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -1856,22 +1856,30 @@ bool QuakeBridgeVisitor::VisitInitListExpr(clang::InitListExpr *x) {
     return true;
   }();
   if (isAllIntOrAllFloat) {
-    SmallVector<Attribute> constantValues;
-    for (auto v : last) {
-      Type type = v.getType();
-      if (auto constantOp = v.getDefiningOp<arith::ConstantFloatOp>())
-        constantValues.push_back(
-            builder.getFloatAttr(type, constantOp.value()));
-      if (auto constantOp = v.getDefiningOp<arith::ConstantIntOp>())
-        constantValues.push_back(
-            builder.getIntegerAttr(type, constantOp.value()));
-    }
     // Clear the types for the init expr
     typeStack.clear();
-    return pushValue(builder.create<cc::ConstantArrayOp>(
-        loc,
-        cc::ArrayType::get(builder.getContext(), last.front().getType(), size),
-        builder.getArrayAttr(constantValues)));
+
+    // This is a initlist on ints or floats, get which one
+    Type dataType = last.front().getType();
+
+    // Add the array size value
+    Value arrSize =
+        getConstantInt(builder, loc, last.size(), builder.getI64Type());
+
+    // Allocate the required memory chunk
+    Value alloca = builder.create<cc::AllocaOp>(loc, dataType, arrSize);
+
+    // Store the values in the allocated memory
+    for (std::size_t i = 0; auto v : last) {
+      Value ptr = builder.create<cc::ComputePtrOp>(
+          loc, cc::PointerType::get(dataType), alloca,
+          getConstantInt(builder, loc, i++, builder.getI64Type()));
+      builder.create<cc::StoreOp>(loc, v, ptr);
+    }
+
+    // Create the stdvec_init op
+    return pushValue(builder.create<cc::StdvecInitOp>(
+        loc, cc::StdvecType::get(dataType), alloca, arrSize));
   }
 
   TODO_x(loc, x, mangler, "list initialization (not quantum ref)");
@@ -1988,10 +1996,32 @@ bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
 
       if (ctorName == "vector") {
         // This is a std::vector constructor, first we'll check if it
-        // is constructed from a constant initializer list
-        if (auto arrTy = dyn_cast<cc::ArrayType>(peekValue().getType()))
-          if (arrTy.getSize() != cc::ArrayType::unknownSize)
-            return true;
+        // is constructed from a constant initializer list, if
+        // so the top value will have stdvec type, and we can just drop out
+        if (isa<cc::StdvecType>(peekValue().getType()))
+          return true;
+
+        // Next check if its created from a size integer
+        if (peekValue().getType().isIntOrFloat()) {
+          auto arrSize = popValue();
+          auto dataType = popType();
+
+          // create stdvec init op without a buffer.
+          // Allocate the required memory chunk
+          Value alloca = builder.create<cc::AllocaOp>(loc, dataType, arrSize);
+
+          // Create the stdvec_init op
+          return pushValue(builder.create<cc::StdvecInitOp>(
+              loc, cc::StdvecType::get(dataType), alloca, arrSize));
+        }
+
+        // Disallow any default vector construction bc we don't
+        // want any .push_back
+        if (ctor->isDefaultConstructor())
+          reportClangError(ctor, mangler,
+                           "Default std::vector<T> constructor within quantum "
+                           "kernel is not allowed "
+                           "(cannot resize the vector).");
       }
     }
 

--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -1973,6 +1973,9 @@ bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
         return true;
       }
 
+      // We check for vector constructors with 2 args, the first
+      // could be an initializer_list or an integer, while the
+      // second is the allocator
       if (ctorName == "vector" && x->getNumArgs() == 2) {
         // Here we create a lambda that will peel off the sugar types
         auto peelOffClangTypes = [&](clang::QualType type) {
@@ -2009,11 +2012,8 @@ bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
           }
         }
 
-        // Next check if its created from a size integer, we should have an
-        // integer value on the stack, and the constructor should have 2 args
-        // one for the size and another for the allocator
-
-        // Lets do a check on the first argument, make sure that when
+        // Next check if its created from a size integer
+        // Let's do a check on the first argument, make sure that when
         // we peel off all the typedefs that it is an integer
         if (auto builtInType =
                 dyn_cast<clang::BuiltinType>(desugared.getTypePtr())) {

--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -1840,12 +1840,12 @@ bool QuakeBridgeVisitor::VisitInitListExpr(clang::InitListExpr *x) {
 
   // Let's allocate some memory and store the init list elements there.
 
-  // Clear the types for the init expr
-  for (std::size_t i = 0; i < size; i++)
-    popType();
+  // Pop the type of the init expr assignment (ConstantArray)
+  Type arrayValueType = popType();
 
   // This is a initlist on ints or floats, get which one
   Type dataType = last.front().getType();
+  assert(arrayValueType == dataType);
 
   // Add the array size value
   Value arrSize =

--- a/test/AST-Quake/vector-ctor-initlist.cpp
+++ b/test/AST-Quake/vector-ctor-initlist.cpp
@@ -8,7 +8,7 @@
 
 // Test for std::vector initializer_list constructor support
 
-// RUN: cudaq-quake %s | cudaq-opt --canonicalize | FileCheck %s
+// RUN: cudaq-quake %s | cudaq-opt | FileCheck %s
 
 #include "cudaq.h"
 

--- a/test/AST-Quake/vector-ctor-initlist.cpp
+++ b/test/AST-Quake/vector-ctor-initlist.cpp
@@ -19,6 +19,7 @@ __qpu__ void test() {
   ry(angle[1], q);
 }
 
+
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_test._Z4testv() attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 0.78539816339744828 : f64
 // CHECK:           %[[VAL_1:.*]] = arith.constant 1.5707963267948966 : f64
@@ -32,8 +33,9 @@ __qpu__ void test() {
 // CHECK:           %[[VAL_7:.*]] = cc.compute_ptr %[[VAL_6]][0] : (!cc.ptr<f64>) -> !cc.ptr<f64>
 // CHECK:           %[[VAL_8:.*]] = cc.load %[[VAL_7]] : !cc.ptr<f64>
 // CHECK:           quake.ry (%[[VAL_8]]) %[[VAL_2]] : (f64, !quake.ref) -> ()
-// CHECK:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_6]][1] : (!cc.ptr<f64>) -> !cc.ptr<f64>
-// CHECK:           %[[VAL_10:.*]] = cc.load %[[VAL_9]] : !cc.ptr<f64>
-// CHECK:           quake.ry (%[[VAL_10]]) %[[VAL_2]] : (f64, !quake.ref) -> ()
+// CHECK:           %[[VAL_9:.*]] = cc.cast %[[VAL_3]] : (!cc.ptr<!cc.array<f64 x 2>>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_10:.*]] = cc.compute_ptr %[[VAL_9]][1] : (!cc.ptr<f64>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_11:.*]] = cc.load %[[VAL_10]] : !cc.ptr<f64>
+// CHECK:           quake.ry (%[[VAL_11]]) %[[VAL_2]] : (f64, !quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/AST-Quake/vector-ctor-initlist.cpp
+++ b/test/AST-Quake/vector-ctor-initlist.cpp
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// Test for std::vector initializer_list constructor support
+
+// RUN: cudaq-quake %s | cudaq-opt --canonicalize | FileCheck %s
+
+#include "cudaq.h"
+
+__qpu__ void test() {
+  cudaq::qubit q;
+  std::vector<double> angle{M_PI_2, M_PI_4};
+  ry(angle[0], q);
+  ry(angle[1], q);
+}
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_test._Z4testv() attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+// CHECK:           %[[VAL_0:.*]] = arith.constant 0.78539816339744828 : f64
+// CHECK:           %[[VAL_1:.*]] = arith.constant 1.5707963267948966 : f64
+// CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[VAL_3:.*]] = cc.alloca !cc.array<f64 x 2>
+// CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_3]][0] : (!cc.ptr<!cc.array<f64 x 2>>) -> !cc.ptr<f64>
+// CHECK:           cc.store %[[VAL_1]], %[[VAL_4]] : !cc.ptr<f64>
+// CHECK:           %[[VAL_5:.*]] = cc.compute_ptr %[[VAL_3]][1] : (!cc.ptr<!cc.array<f64 x 2>>) -> !cc.ptr<f64>
+// CHECK:           cc.store %[[VAL_0]], %[[VAL_5]] : !cc.ptr<f64>
+// CHECK:           %[[VAL_6:.*]] = cc.cast %[[VAL_3]] : (!cc.ptr<!cc.array<f64 x 2>>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_7:.*]] = cc.compute_ptr %[[VAL_6]][0] : (!cc.ptr<f64>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_8:.*]] = cc.load %[[VAL_7]] : !cc.ptr<f64>
+// CHECK:           quake.ry (%[[VAL_8]]) %[[VAL_2]] : (f64, !quake.ref) -> ()
+// CHECK:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_6]][1] : (!cc.ptr<f64>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_10:.*]] = cc.load %[[VAL_9]] : !cc.ptr<f64>
+// CHECK:           quake.ry (%[[VAL_10]]) %[[VAL_2]] : (f64, !quake.ref) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/AST-Quake/vector-ctor-initlist.cpp
+++ b/test/AST-Quake/vector-ctor-initlist.cpp
@@ -39,3 +39,38 @@ __qpu__ void test() {
 // CHECK:           quake.ry (%[[VAL_11]]) %[[VAL_2]] : (f64, !quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
+
+__qpu__ void test1() {
+  cudaq::qubit q;
+  std::vector<double> angle{M_PI_2};
+  // clang-format off
+  // CHECK:           %[[VAL_0:.*]] = arith.constant 1.5707963267948966 : f64
+  // CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
+  // CHECK:           %[[VAL_2:.*]] = cc.alloca !cc.array<f64 x 1>
+  // CHECK:           %[[VAL_3:.*]] = cc.compute_ptr %[[VAL_2]][0] : (!cc.ptr<!cc.array<f64 x 1>>) -> !cc.ptr<f64>
+  // CHECK:           cc.store %[[VAL_0]], %[[VAL_3]] : !cc.ptr<f64>
+  // clang-format on
+  ry(angle[0], q);
+}
+
+__qpu__ void test3() {
+  cudaq::qubit q;
+  std::vector<double> angle{M_PI_2, M_PI_4, M_PI};
+  // clang-format off
+  // CHECK:           %[[VAL_0:.*]] = arith.constant 3.1415926535897931 : f64
+  // CHECK:           %[[VAL_1:.*]] = arith.constant 0.78539816339744828 : f64
+  // CHECK:           %[[VAL_2:.*]] = arith.constant 1.5707963267948966 : f64
+  // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.ref
+  // CHECK:           %[[VAL_4:.*]] = cc.alloca !cc.array<f64 x 3>
+  // CHECK:           %[[VAL_5:.*]] = cc.compute_ptr %[[VAL_4]][0] : (!cc.ptr<!cc.array<f64 x 3>>) -> !cc.ptr<f64>
+  // CHECK:           cc.store %[[VAL_2]], %[[VAL_5]] : !cc.ptr<f64>
+  // CHECK:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_4]][1] : (!cc.ptr<!cc.array<f64 x 3>>) -> !cc.ptr<f64>
+  // CHECK:           cc.store %[[VAL_1]], %[[VAL_6]] : !cc.ptr<f64>
+  // CHECK:           %[[VAL_7:.*]] = cc.compute_ptr %[[VAL_4]][2] : (!cc.ptr<!cc.array<f64 x 3>>) -> !cc.ptr<f64>
+  // CHECK:           cc.store %[[VAL_0]], %[[VAL_7]] : !cc.ptr<f64>
+  // clang-format on
+
+  ry(angle[0], q);
+  ry(angle[1], q);
+  ry(angle[2], q);
+}

--- a/test/AST-Quake/vector-ctor-sized.cpp
+++ b/test/AST-Quake/vector-ctor-sized.cpp
@@ -8,7 +8,7 @@
 
 // Test for std::vector initializer_list constructor support
 
-// RUN: cudaq-quake %s | cudaq-opt --canonicalize | FileCheck %s
+// RUN: cudaq-quake %s | cudaq-opt | FileCheck %s
 
 #include "cudaq.h"
 

--- a/test/AST-Quake/vector-ctor-sized.cpp
+++ b/test/AST-Quake/vector-ctor-sized.cpp
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// Test for std::vector initializer_list constructor support
+
+// RUN: cudaq-quake %s | cudaq-opt --canonicalize | FileCheck %s
+
+#include "cudaq.h"
+
+__qpu__ void test() {
+  cudaq::qubit q;
+  std::vector<double> angle(2);   
+  angle[0] = M_PI_2;
+  angle[1] = M_PI_4;
+  ry(angle[0], q);
+  ry(angle[1], q);
+
+}
+
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_test._Z4testv() attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+// CHECK:           %[[VAL_0:.*]] = arith.constant 0.78539816339744828 : f64
+// CHECK:           %[[VAL_1:.*]] = arith.constant 1.5707963267948966 : f64
+// CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[VAL_3:.*]] = cc.alloca !cc.array<f64 x 2>
+// CHECK:           %[[VAL_4:.*]] = cc.cast %[[VAL_3]] : (!cc.ptr<!cc.array<f64 x 2>>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_5:.*]] = cc.compute_ptr %[[VAL_4]][0] : (!cc.ptr<f64>) -> !cc.ptr<f64>
+// CHECK:           cc.store %[[VAL_1]], %[[VAL_5]] : !cc.ptr<f64>
+// CHECK:           %[[VAL_6:.*]] = cc.cast %[[VAL_3]] : (!cc.ptr<!cc.array<f64 x 2>>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_7:.*]] = cc.compute_ptr %[[VAL_6]][1] : (!cc.ptr<f64>) -> !cc.ptr<f64>
+// CHECK:           cc.store %[[VAL_0]], %[[VAL_7]] : !cc.ptr<f64>
+// CHECK:           %[[VAL_8:.*]] = cc.cast %[[VAL_3]] : (!cc.ptr<!cc.array<f64 x 2>>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_8]][0] : (!cc.ptr<f64>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_10:.*]] = cc.load %[[VAL_9]] : !cc.ptr<f64>
+// CHECK:           quake.ry (%[[VAL_10]]) %[[VAL_2]] : (f64, !quake.ref) -> ()
+// CHECK:           %[[VAL_11:.*]] = cc.cast %[[VAL_3]] : (!cc.ptr<!cc.array<f64 x 2>>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_12:.*]] = cc.compute_ptr %[[VAL_11]][1] : (!cc.ptr<f64>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_13:.*]] = cc.load %[[VAL_12]] : !cc.ptr<f64>
+// CHECK:           quake.ry (%[[VAL_13]]) %[[VAL_2]] : (f64, !quake.ref) -> ()
+// CHECK:           return
+// CHECK:         }


### PR DESCRIPTION


<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
When we visit a `CXXStdInitializerListExpr`, we push into the `Type` stack: (1) Template specialization Type and (2) the element Type of the const array. Importantly, we **don't** push the type of each Float/Int literal:
```
bool QuakeBridgeVisitor::VisitFloatingLiteral(clang::FloatingLiteral *x) {
// Literals do not push a type on the type stack.
```
Hence, popping Type stack based on the number of init list elements will hit the stack size assertion.

The current code worked only if the init list contains one or two values :) 
Note: `VisitVarDecl` gracefully handled the cases where we left one or zero value on the Type stack.

Fixed by popping only a single Type from the stack. Adding some tests accordingly.