### PR TITLE
This is an attempt to sort out the different ownership models of tens…

### DIFF
--- a/python/runtime/utils/py_tensor.cpp
+++ b/python/runtime/utils/py_tensor.cpp
@@ -93,7 +93,7 @@ Notes:
              py::buffer_info info = b.request();
              std::vector<std::size_t> shape(info.shape.begin(),
                                             info.shape.end());
-             t.take(static_cast<Scalar *>(info.ptr), shape);
+             //t.take(static_cast<Scalar *>(info.ptr), shape);
            })
       .def("borrow",
            [](Tensor &t, py::array_t<Scalar, py::array::c_style> b) {

--- a/python/runtime/utils/py_tensor.cpp
+++ b/python/runtime/utils/py_tensor.cpp
@@ -93,7 +93,12 @@ Notes:
              py::buffer_info info = b.request();
              std::vector<std::size_t> shape(info.shape.begin(),
                                             info.shape.end());
-             //t.take(static_cast<Scalar *>(info.ptr), shape);
+             auto size = std::accumulate(shape.begin(), shape.end(), 1,
+                                         std::multiplies<std::size_t>());
+             auto data = std::make_unique<Scalar[]>(size);
+             Scalar *pdata = static_cast<Scalar *>(info.ptr);
+             std::copy(pdata, pdata + size, data.get());
+             t.take(data, shape);
            })
       .def("borrow",
            [](Tensor &t, py::array_t<Scalar, py::array::c_style> b) {

--- a/runtime/cudaq/utils/details/impls/xtensor_impl.cpp
+++ b/runtime/cudaq/utils/details/impls/xtensor_impl.cpp
@@ -14,18 +14,24 @@
 
 namespace cudaq {
 
+using xtensor_shape_type = std::vector<std::size_t>;
+
 /// @brief An implementation of tensor_impl using xtensor library
 template <typename Scalar>
 class xtensor : public cudaq::details::tensor_impl<Scalar> {
 private:
-  Scalar *m_data = nullptr;         ///< Pointer to the tensor data
-  std::vector<std::size_t> m_shape; ///< Shape of the tensor
-  bool ownsData = true; ///< Flag indicating if this object owns the data
+  std::unique_ptr<Scalar[]> owned_data = {}; ///< Pointer to owned tensor data
+  Scalar *borrow_data = nullptr; ///< Pointer to borrowed tensor data
+  xtensor_shape_type m_shape;    ///< Shape of the tensor
+
+  /// Enum indicating style of ownership of the raw data
+  enum OwnershipMode { Invalid, OwnedByCopy, OwnedByTake, Borrowed };
+  OwnershipMode ownership = Invalid;
 
   /// @brief Check if the given indices are valid for this tensor
   /// @param idxs Vector of indices to check
   /// @return true if indices are valid, false otherwise
-  bool validIndices(const std::vector<std::size_t> &idxs) const {
+  bool validIndices(const xtensor_shape_type &idxs) const {
     if (idxs.size() != m_shape.size())
       return false;
     for (std::size_t dim = 0; auto idx : idxs)
@@ -34,12 +40,81 @@ private:
     return true;
   }
 
+  Scalar *m_data() const {
+    switch (ownership) {
+    case Invalid:
+      return nullptr;
+    case OwnedByCopy:
+    case OwnedByTake:
+      return owned_data.get();
+    case Borrowed:
+      return borrow_data;
+    }
+  }
+
+  // Clear the data.
+  void deallocate() {
+    switch (ownership) {
+    case Invalid:
+      return;
+    case OwnedByCopy:
+      // This is the one case that the tensor object has done allocation.
+      owned_data.release();
+      break;
+    case OwnedByTake:
+      break;
+    case Borrowed:
+      borrow_data = nullptr;
+      break;
+    }
+    ownership = Invalid;
+  }
+
 public:
-  /// @brief Constructor for xtensor
-  /// @param d Pointer to the tensor data
-  /// @param s Shape of the tensor
-  xtensor(const Scalar *d, const std::vector<std::size_t> &s)
-      : m_data(const_cast<Scalar *>(d)), m_shape(s) {}
+  xtensor() = delete;
+  xtensor(const Scalar *d, const xtensor_shape_type &shape) { copy(d, shape); }
+  xtensor(const xtensor &from) {
+    m_shape = from.m_shape;
+    ownership = from.ownership;
+    switch (ownership) {
+    case OwnedByCopy: {
+      auto size = std::accumulate(m_shape.begin(), m_shape.end(), 1,
+                                  std::multiplies<std::size_t>());
+      owned_data = std::make_unique<Scalar[]>(size);
+      auto *d = from.owned_data.get();
+      std::copy(d, d + size, owned_data.get());
+    } break;
+    case OwnedByTake:
+      owned_data.swap(from.owned_data);
+      break;
+    case Borrowed:
+      borrow_data = from.borrow_data;
+      break;
+    }
+  }
+  xtensor &operator=(const xtensor &from) {
+    m_shape = from.m_shape;
+    ownership = from.ownership;
+    switch (ownership) {
+    case OwnedByCopy: {
+      auto size = std::accumulate(m_shape.begin(), m_shape.end(), 1,
+                                  std::multiplies<std::size_t>());
+      owned_data = std::make_unique<Scalar[]>(size);
+      auto *d = from.owned_data.get();
+      std::copy(d, d + size, owned_data.get());
+    } break;
+    case OwnedByTake:
+      owned_data.swap(from.owned_data);
+      break;
+    case Borrowed:
+      borrow_data = from.borrow_data;
+      break;
+    }
+    return *this;
+  }
+
+  /// @brief Destructor for xtensor
+  ~xtensor() { ownership = Invalid; }
 
   /// @brief Get the rank of the tensor
   /// @return The rank (number of dimensions) of the tensor
@@ -49,73 +124,76 @@ public:
   /// @return The total number of elements in the tensor
   std::size_t size() const override {
     return std::accumulate(m_shape.begin(), m_shape.end(), 1,
-                           std::multiplies<size_t>());
+                           std::multiplies<std::size_t>());
   }
 
   /// @brief Get the shape of the tensor
   /// @return A vector containing the dimensions of the tensor
-  std::vector<std::size_t> shape() const override { return m_shape; }
+  xtensor_shape_type shape() const override { return m_shape; }
 
   /// @brief Access a mutable element of the tensor
   /// @param indices The indices of the element to access
   /// @return A reference to the element at the specified indices
   /// @throws std::runtime_error if indices are invalid
-  Scalar &at(const std::vector<size_t> &indices) override {
+  Scalar &at(const xtensor_shape_type &indices) override {
     if (!validIndices(indices))
       throw std::runtime_error("Invalid tensor indices: " +
                                fmt::format("{}", fmt::join(indices, ", ")));
 
-    return xt::adapt(m_data, size(), xt::no_ownership(), m_shape)[indices];
+    return xt::adapt(m_data(), size(), xt::no_ownership(), m_shape)[indices];
   }
 
   /// @brief Access a const element of the tensor
   /// @param indices The indices of the element to access
   /// @return A const reference to the element at the specified indices
   /// @throws std::runtime_error if indices are invalid
-  const Scalar &at(const std::vector<size_t> &indices) const override {
+  const Scalar &at(const xtensor_shape_type &indices) const override {
     if (!validIndices(indices))
       throw std::runtime_error("Invalid constant tensor indices: " +
                                fmt::format("{}", fmt::join(indices, ", ")));
-    return xt::adapt(m_data, size(), xt::no_ownership(), m_shape)[indices];
+    return xt::adapt(m_data(), size(), xt::no_ownership(), m_shape)[indices];
   }
 
   /// @brief Copy data into the tensor
   /// @param d Pointer to the source data
   /// @param shape The shape of the source data
-  void copy(const Scalar *d, const std::vector<std::size_t> &shape) override {
+  void copy(const Scalar *d, const xtensor_shape_type &shape) override {
+    deallocate();
+    ownership = OwnedByCopy;
     auto size = std::accumulate(shape.begin(), shape.end(), 1,
-                                std::multiplies<size_t>());
-    if (m_data)
-      delete m_data;
-
-    m_data = m_data = new Scalar[size];
-    std::copy(d, d + size, m_data);
+                                std::multiplies<std::size_t>());
+    auto newData = std::make_unique<Scalar[]>(size);
+    owned_data.swap(newData);
+    std::copy(d, d + size, owned_data.get());
     m_shape = shape;
-    ownsData = true;
   }
 
   /// @brief Take ownership of the given data
   /// @param d Pointer to the source data
   /// @param shape The shape of the source data
-  void take(const Scalar *d, const std::vector<std::size_t> &shape) override {
-    m_data = const_cast<Scalar *>(d);
+  void take(std::unique_ptr<Scalar[]> &d,
+            const xtensor_shape_type &shape) override {
+    deallocate();
+    ownership = OwnedByTake;
+    owned_data.swap(d);
     m_shape = shape;
-    ownsData = true;
   }
 
   /// @brief Borrow the given data without taking ownership
   /// @param d Pointer to the source data
   /// @param shape The shape of the source data
-  void borrow(const Scalar *d, const std::vector<std::size_t> &shape) override {
-    m_data = const_cast<Scalar *>(d);
+  void borrow(const Scalar *d, const xtensor_shape_type &shape) override {
+    deallocate();
+    ownership = Borrowed;
+    borrow_data = const_cast<Scalar *>(d);
     m_shape = shape;
-    ownsData = false;
   }
 
-  Scalar *data() override { return m_data; }
-  const Scalar *data() const override { return m_data; }
+  Scalar *data() override { return m_data(); }
+  const Scalar *data() const override { return m_data(); }
   void dump() const override {
-    std::cerr << xt::adapt(m_data, size(), xt::no_ownership(), m_shape) << '\n';
+    std::cerr << xt::adapt(m_data(), size(), xt::no_ownership(), m_shape)
+              << '\n';
   }
 
   static constexpr auto ScalarAsString = cudaq::type_to_string<Scalar>();
@@ -127,15 +205,9 @@ public:
   CUDAQ_EXTENSION_CUSTOM_CREATOR_FUNCTION_WITH_NAME(
       xtensor<Scalar>, std::string("xtensor") + std::string(ScalarAsString),
       static std::unique_ptr<cudaq::details::tensor_impl<Scalar>> create(
-          const Scalar *d, const std::vector<std::size_t> s) {
+          const Scalar *d, const xtensor_shape_type s) {
         return std::make_unique<xtensor<Scalar>>(d, s);
       })
-
-  /// @brief Destructor for xtensor
-  ~xtensor() {
-    if (ownsData)
-      delete m_data;
-  }
 };
 
 // Register all the xtensor types.

--- a/runtime/cudaq/utils/details/impls/xtensor_impl.cpp
+++ b/runtime/cudaq/utils/details/impls/xtensor_impl.cpp
@@ -70,6 +70,13 @@ private:
     ownership = Invalid;
   }
 
+  static std::size_t compute_shape_size(const xtensor_shape_type &shape) {
+    if (shape.empty())
+      return 0;
+    return std::accumulate(shape.begin(), shape.end(), 1,
+                           std::multiplies<std::size_t>());
+  }
+
 public:
   xtensor() = delete;
   xtensor(const Scalar *d, const xtensor_shape_type &shape) { copy(d, shape); }
@@ -78,8 +85,7 @@ public:
     ownership = from.ownership;
     switch (ownership) {
     case OwnedByCopy: {
-      auto size = std::accumulate(m_shape.begin(), m_shape.end(), 1,
-                                  std::multiplies<std::size_t>());
+      auto size = compute_shape_size(m_shape);
       owned_data = std::make_unique<Scalar[]>(size);
       auto *d = from.owned_data.get();
       std::copy(d, d + size, owned_data.get());
@@ -97,8 +103,7 @@ public:
     ownership = from.ownership;
     switch (ownership) {
     case OwnedByCopy: {
-      auto size = std::accumulate(m_shape.begin(), m_shape.end(), 1,
-                                  std::multiplies<std::size_t>());
+      auto size = compute_shape_size(m_shape);
       owned_data = std::make_unique<Scalar[]>(size);
       auto *d = from.owned_data.get();
       std::copy(d, d + size, owned_data.get());
@@ -122,10 +127,7 @@ public:
 
   /// @brief Get the total size of the tensor
   /// @return The total number of elements in the tensor
-  std::size_t size() const override {
-    return std::accumulate(m_shape.begin(), m_shape.end(), 1,
-                           std::multiplies<std::size_t>());
-  }
+  std::size_t size() const override { return compute_shape_size(m_shape); }
 
   /// @brief Get the shape of the tensor
   /// @return A vector containing the dimensions of the tensor
@@ -160,8 +162,7 @@ public:
   void copy(const Scalar *d, const xtensor_shape_type &shape) override {
     deallocate();
     ownership = OwnedByCopy;
-    auto size = std::accumulate(shape.begin(), shape.end(), 1,
-                                std::multiplies<std::size_t>());
+    auto size = compute_shape_size(shape);
     auto newData = std::make_unique<Scalar[]>(size);
     owned_data.swap(newData);
     std::copy(d, d + size, owned_data.get());

--- a/runtime/cudaq/utils/details/tensor_impl.h
+++ b/runtime/cudaq/utils/details/tensor_impl.h
@@ -97,7 +97,7 @@ public:
   /// @brief Take ownership of the given data
   /// @param data Pointer to the source data
   /// @param shape The shape of the source data
-  virtual void take(const scalar_type *data,
+  virtual void take(std::unique_ptr<scalar_type[]> &data,
                     const std::vector<std::size_t> &shape) = 0;
 
   /// @brief Borrow the given data without taking ownership

--- a/runtime/cudaq/utils/tensor.h
+++ b/runtime/cudaq/utils/tensor.h
@@ -95,7 +95,7 @@ public:
   /// @brief Take ownership of the given data
   /// @param data Pointer to the source data
   /// @param shape The shape of the source data
-  void take(const scalar_type *data,
+  void take(std::unique_ptr<scalar_type[]> &data,
             const std::vector<std::size_t> shape = {}) {
     if (pimpl->shape().empty() && shape.empty())
       throw std::runtime_error(

--- a/unittests/utils/tensor_tester.cpp
+++ b/unittests/utils/tensor_tester.cpp
@@ -65,8 +65,10 @@ TEST(CoreTester, checkTensorSimple) {
   }
   {
     cudaq::tensor t;
-    std::vector<std::complex<double>> data{1, 2, 3, 4};
-    EXPECT_THROW({ t.take(data.data()); }, std::runtime_error);
+    const std::vector<std::complex<double>> idata{1, 2, 3, 4};
+    auto data = std::make_unique<std::complex<double>[]>(4);
+    std::copy(idata.begin(), idata.end(), data.get());
+    EXPECT_THROW({ t.take(data); }, std::runtime_error);
   }
   {
     cudaq::tensor t({2, 2});
@@ -125,16 +127,18 @@ TEST(CoreTester, checkTensorSimple) {
   }
   {
     cudaq::tensor t;
-    std::vector<std::complex<double>> data{1, 2, 3, 4};
-    EXPECT_THROW({ t.take(data.data()); }, std::runtime_error);
+    const std::vector<std::complex<double>> idata{1, 2, 3, 4};
+    auto data = std::make_unique<std::complex<double>[]>(4);
+    std::copy(idata.begin(), idata.end(), data.get());
+    EXPECT_THROW({ t.take(data); }, std::runtime_error);
   }
   {
     cudaq::tensor t({2, 2});
     EXPECT_EQ(t.rank(), 2);
     EXPECT_EQ(t.size(), 4);
-    std::complex<double> *data = new std::complex<double>[4];
+    auto data = std::make_unique<std::complex<double>[]>(4);
     double count = 1.0;
-    std::generate_n(data, 4, [&]() { return count++; });
+    std::generate_n(data.get(), 4, [&]() { return count++; });
     t.take(data, {2, 2});
     EXPECT_NEAR(t.at({0, 0}).real(), 1., 1e-8);
     EXPECT_NEAR(t.at({0, 1}).real(), 2., 1e-8);
@@ -219,9 +223,10 @@ TEST(TensorTest, CopyData) {
 
 TEST(TensorTest, TakeData) {
   std::vector<std::size_t> shape = {2, 2};
-  auto data = new std::complex<double>[4] {
-    {1.0, 0.0}, {0.0, 1.0}, {0.0, -1.0}, { 1.0, 0.0 }
-  };
+  auto data = std::make_unique<std::complex<double>[]>(4);
+  const std::vector<std::complex<double>> idata{
+      {1.0, 0.0}, {0.0, 1.0}, {0.0, -1.0}, {1.0, 0.0}};
+  std::copy(idata.begin(), idata.end(), data.get());
   cudaq::tensor t(shape);
 
   t.take(data, shape);


### PR DESCRIPTION
…or data.

~The python stub for "take" needs to be implemented however.~

The semantics are:

  - copy : the tensor object makes a copy of the data and owns the copy. i.e. there is a unique_ptr.
  - take : the tensor object steals a copy of the data from the caller. In order for this case to make sense, we want the caller to guarantee that the data is unique before we steal it. This can be done by forcing the client code to wrap the tensor data in a unique_ptr *before* the take call.
  - borrow : In this case, the tensor object has no ownership of the tensor data and just naively assumes the client will manage the data correctly. In this case, a raw pointer to the client's data is used.

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
